### PR TITLE
✨feat: 물품 상세조회 기능 구현

### DIFF
--- a/src/main/java/com/example/shoppingmall/domain/item/api/ItemController.java
+++ b/src/main/java/com/example/shoppingmall/domain/item/api/ItemController.java
@@ -15,12 +15,6 @@ public class ItemController {
 
     private final ItemService itemService;
 
-    @GetMapping
-    public ResponseEntity<Page<ItemResponse>> getItemMainPage(
-            @RequestParam(name = "page", defaultValue = "1") int pageNum) {
-
-        return ResponseEntity.ok(itemService.getItemMainPage(pageNum));
-    }
 
     @GetMapping("/{item_id}")
     public ResponseEntity<ItemDetailResponse> getItemDetail(

--- a/src/main/java/com/example/shoppingmall/domain/item/api/ItemController.java
+++ b/src/main/java/com/example/shoppingmall/domain/item/api/ItemController.java
@@ -1,14 +1,12 @@
 package com.example.shoppingmall.domain.item.api;
 
 import com.example.shoppingmall.domain.item.application.ItemService;
+import com.example.shoppingmall.domain.item.dto.ItemDetailResponse;
 import com.example.shoppingmall.domain.item.dto.ItemResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -19,8 +17,15 @@ public class ItemController {
 
     @GetMapping
     public ResponseEntity<Page<ItemResponse>> getItemMainPage(
-            @RequestParam(name = "page", defaultValue = "1") int pageNum ) {
+            @RequestParam(name = "page", defaultValue = "1") int pageNum) {
 
         return ResponseEntity.ok(itemService.getItemMainPage(pageNum));
+    }
+
+    @GetMapping("/{item_id}")
+    public ResponseEntity<ItemDetailResponse> getItemDetail(
+            @PathVariable("item_id") long itemId) {
+
+        return ResponseEntity.ok(itemService.getItemDetail(itemId));
     }
 }

--- a/src/main/java/com/example/shoppingmall/domain/item/api/ItemController.java
+++ b/src/main/java/com/example/shoppingmall/domain/item/api/ItemController.java
@@ -1,8 +1,26 @@
 package com.example.shoppingmall.domain.item.api;
 
+import com.example.shoppingmall.domain.item.application.ItemService;
+import com.example.shoppingmall.domain.item.dto.ItemResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@RequiredArgsConstructor
 @RestController
+@RequestMapping("/items")
 public class ItemController {
 
+    private final ItemService itemService;
+
+    @GetMapping
+    public ResponseEntity<Page<ItemResponse>> getItemMainPage(
+            @RequestParam(name = "page", defaultValue = "1") int pageNum ) {
+
+        return ResponseEntity.ok(itemService.getItemMainPage(pageNum));
+    }
 }

--- a/src/main/java/com/example/shoppingmall/domain/item/application/ItemService.java
+++ b/src/main/java/com/example/shoppingmall/domain/item/application/ItemService.java
@@ -24,12 +24,6 @@ public class ItemService {
     private final ItemRepository itemRepository;
     private final ImageRepository imageRepository;
 
-    public Page<ItemResponse> getItemMainPage(int pageNum) {
-        PageRequest pageRequest = PageRequest.of(pageNum, 12, Sort.by(DESC, "created_at"));
-
-        return itemRepository
-                .findMainPage(pageRequest).map(ItemResponse::new);
-    }
 
     public ItemDetailResponse getItemDetail(long itemId) {
 

--- a/src/main/java/com/example/shoppingmall/domain/item/application/ItemService.java
+++ b/src/main/java/com/example/shoppingmall/domain/item/application/ItemService.java
@@ -1,7 +1,24 @@
 package com.example.shoppingmall.domain.item.application;
 
+import com.example.shoppingmall.domain.item.dao.ItemRepository;
+import com.example.shoppingmall.domain.item.dto.ItemResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+import static org.springframework.data.domain.Sort.Direction.DESC;
+
+@RequiredArgsConstructor
 @Service
 public class ItemService {
+
+    private final ItemRepository itemRepository;
+    public Page<ItemResponse> getItemMainPage(int pageNum) {
+        PageRequest pageRequest = PageRequest.of(pageNum, 12, Sort.by(DESC, "created_at"));
+
+        return itemRepository
+                .findAll(pageRequest).map(ItemResponse::new);
+    }
 }

--- a/src/main/java/com/example/shoppingmall/domain/item/application/ItemService.java
+++ b/src/main/java/com/example/shoppingmall/domain/item/application/ItemService.java
@@ -1,24 +1,41 @@
 package com.example.shoppingmall.domain.item.application;
 
+import com.example.shoppingmall.domain.item.dao.ImageRepository;
 import com.example.shoppingmall.domain.item.dao.ItemRepository;
+import com.example.shoppingmall.domain.item.domain.Item;
+import com.example.shoppingmall.domain.item.dto.ItemDetailResponse;
 import com.example.shoppingmall.domain.item.dto.ItemResponse;
+import com.example.shoppingmall.domain.item.excepction.ItemException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import static com.example.shoppingmall.global.exception.ErrorCode.NOT_FOUND_ITEM;
 import static org.springframework.data.domain.Sort.Direction.DESC;
 
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
 public class ItemService {
 
     private final ItemRepository itemRepository;
+    private final ImageRepository imageRepository;
+
     public Page<ItemResponse> getItemMainPage(int pageNum) {
         PageRequest pageRequest = PageRequest.of(pageNum, 12, Sort.by(DESC, "created_at"));
 
         return itemRepository
                 .findMainPage(pageRequest).map(ItemResponse::new);
+    }
+
+    public ItemDetailResponse getItemDetail(long itemId) {
+
+        Item item = itemRepository.findItemAndStockAndSeller(itemId)
+                .orElseThrow(() -> new ItemException(NOT_FOUND_ITEM));
+
+        return new ItemDetailResponse(item, imageRepository.findAllByItemId(item.getId()));
     }
 }

--- a/src/main/java/com/example/shoppingmall/domain/item/application/ItemService.java
+++ b/src/main/java/com/example/shoppingmall/domain/item/application/ItemService.java
@@ -19,6 +19,6 @@ public class ItemService {
         PageRequest pageRequest = PageRequest.of(pageNum, 12, Sort.by(DESC, "created_at"));
 
         return itemRepository
-                .findAll(pageRequest).map(ItemResponse::new);
+                .findMainPage(pageRequest).map(ItemResponse::new);
     }
 }

--- a/src/main/java/com/example/shoppingmall/domain/item/dao/ImageRepository.java
+++ b/src/main/java/com/example/shoppingmall/domain/item/dao/ImageRepository.java
@@ -1,0 +1,11 @@
+package com.example.shoppingmall.domain.item.dao;
+
+import com.example.shoppingmall.domain.item.domain.ItemImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ImageRepository extends JpaRepository<ItemImage, Long> {
+
+    List<ItemImage> findAllByItemId(Long itemId);
+}

--- a/src/main/java/com/example/shoppingmall/domain/item/dao/ItemRepository.java
+++ b/src/main/java/com/example/shoppingmall/domain/item/dao/ItemRepository.java
@@ -1,9 +1,13 @@
 package com.example.shoppingmall.domain.item.dao;
 
 import com.example.shoppingmall.domain.item.domain.Item;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ItemRepository extends JpaRepository<Item, Long> {
+
+    Page<Item> findMainPage(Pageable pageable);
 }

--- a/src/main/java/com/example/shoppingmall/domain/item/dao/ItemRepository.java
+++ b/src/main/java/com/example/shoppingmall/domain/item/dao/ItemRepository.java
@@ -12,7 +12,6 @@ import java.util.Optional;
 @Repository
 public interface ItemRepository extends JpaRepository<Item, Long> {
 
-    Page<Item> findMainPage(Pageable pageable);
     @Query("select i from Item i join fetch i.user join fetch i.stocks where i.id = :itemId")
     Optional<Item> findItemAndStockAndSeller(Long itemId);
 }

--- a/src/main/java/com/example/shoppingmall/domain/item/dao/ItemRepository.java
+++ b/src/main/java/com/example/shoppingmall/domain/item/dao/ItemRepository.java
@@ -4,10 +4,15 @@ import com.example.shoppingmall.domain.item.domain.Item;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface ItemRepository extends JpaRepository<Item, Long> {
 
     Page<Item> findMainPage(Pageable pageable);
+    @Query("select i from Item i join fetch i.user join fetch i.stocks where i.id = :itemId")
+    Optional<Item> findItemAndStockAndSeller(Long itemId);
 }

--- a/src/main/java/com/example/shoppingmall/domain/item/domain/Item.java
+++ b/src/main/java/com/example/shoppingmall/domain/item/domain/Item.java
@@ -3,9 +3,7 @@ package com.example.shoppingmall.domain.item.domain;
 import com.example.shoppingmall.domain.common.BaseTimeEntity;
 import com.example.shoppingmall.domain.user.domain.User;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -14,6 +12,8 @@ import java.util.List;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
@@ -35,10 +35,12 @@ public class Item extends BaseTimeEntity {
     @Column(name = "item_price", nullable = false)
     private Integer price;
 
-    @OneToMany(mappedBy = "item")
+    @Builder.Default
+    @OneToMany(mappedBy = "item", cascade = CascadeType.PERSIST)
     private List<ItemImage> images = new ArrayList<>();
 
-    @OneToMany(mappedBy = "item")
+    @Builder.Default
+    @OneToMany(mappedBy = "item", cascade = CascadeType.PERSIST)
     private List<ItemStock> stocks = new ArrayList<>();
 
     @Column(name = "thumbnail_url")

--- a/src/main/java/com/example/shoppingmall/domain/item/domain/Item.java
+++ b/src/main/java/com/example/shoppingmall/domain/item/domain/Item.java
@@ -38,25 +38,30 @@ public class Item extends BaseTimeEntity {
     @OneToMany(mappedBy = "item")
     private List<ItemImage> images = new ArrayList<>();
 
+    @OneToMany(mappedBy = "item")
+    private List<ItemStock> stocks = new ArrayList<>();
+
     @Column(name = "thumbnail_url")
     private String thumbnailUrl;
 
     @Column(nullable = false, name = "expired_at")
     private LocalDateTime expiredAt;
 
-    @Column(name = "thumbnail_url", nullable = false)
-    private String thumbnailUrl;
 
     // TODO 조회 수 구현하게 될 때 생각해볼 예정
     @Column(nullable = false, name = "hit_count")
     private Long hitCount;
 
+    @Column(nullable = false)
+    private String description;
+
 
     /* TODO 양방향 고려
      *  - cart_item
      *  - order_item
-     *  - item_stock
      *  - item_category
+     *
+     *  - item_stock
      *  - item_image
      */
 }

--- a/src/main/java/com/example/shoppingmall/domain/item/domain/Item.java
+++ b/src/main/java/com/example/shoppingmall/domain/item/domain/Item.java
@@ -1,6 +1,7 @@
 package com.example.shoppingmall.domain.item.domain;
 
 import com.example.shoppingmall.domain.common.BaseTimeEntity;
+import com.example.shoppingmall.domain.item.type.ClothingSize;
 import com.example.shoppingmall.domain.user.domain.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -57,6 +58,25 @@ public class Item extends BaseTimeEntity {
     @Column(nullable = false)
     private String description;
 
+
+    /**
+     * 이미 존재하는 옵션의 재고 수정 X
+     * 새로운 옵션 자체를 추가
+     */
+    public void addStockOption(ClothingSize size, int stock) {
+
+        for (ItemStock itemStock : stocks) {
+            if(itemStock!= null && itemStock.getSize().equals(size)){
+                itemStock.addStock(stock);
+                break;
+            }
+        }
+        stocks.add(new ItemStock(this, size, stock));
+    }
+
+    public void addImage(String imageUrl) {
+        images.add(new ItemImage(this, imageUrl));
+    }
 
     /* TODO 양방향 고려
      *  - cart_item

--- a/src/main/java/com/example/shoppingmall/domain/item/domain/Item.java
+++ b/src/main/java/com/example/shoppingmall/domain/item/domain/Item.java
@@ -41,6 +41,9 @@ public class Item extends BaseTimeEntity {
     @Column(nullable = false)
     private LocalDateTime expiredAt;
 
+    @Column(name = "thumbnail_url", nullable = false)
+    private String thumbnailUrl;
+
     // TODO 조회 수 구현하게 될 때 생각해볼 예정
     private long hitCount;
 

--- a/src/main/java/com/example/shoppingmall/domain/item/domain/ItemImage.java
+++ b/src/main/java/com/example/shoppingmall/domain/item/domain/ItemImage.java
@@ -28,4 +28,10 @@ public class ItemImage {
         this.item = item;
         this.imageUrl = imageUrl;
     }
+
+    public ItemImage(Long imageId, Item item, String imageUrl) {
+        this.id = imageId;
+        this.item = item;
+        this.imageUrl = imageUrl;
+    }
 }

--- a/src/main/java/com/example/shoppingmall/domain/item/domain/ItemImage.java
+++ b/src/main/java/com/example/shoppingmall/domain/item/domain/ItemImage.java
@@ -24,4 +24,8 @@ public class ItemImage {
     @Column(name = "image_url", nullable = false)
     private String imageUrl;
 
+    public ItemImage(Item item, String imageUrl) {
+        this.item = item;
+        this.imageUrl = imageUrl;
+    }
 }

--- a/src/main/java/com/example/shoppingmall/domain/item/domain/ItemStock.java
+++ b/src/main/java/com/example/shoppingmall/domain/item/domain/ItemStock.java
@@ -6,8 +6,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import static jakarta.persistence.EnumType.*;
-import static jakarta.persistence.FetchType.*;
+import static jakarta.persistence.EnumType.STRING;
+import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -32,4 +32,13 @@ public class ItemStock {
     @ManyToOne(fetch = LAZY)
     private Item item;
 
+    public ItemStock(Item item, ClothingSize size, Integer stock) {
+        this.item = item;
+        this.size = size;
+        this.stock = stock;
+    }
+
+    public void addStock(int stock) {
+        this.stock += stock;
+    }
 }

--- a/src/main/java/com/example/shoppingmall/domain/item/dto/ItemDetailResponse.java
+++ b/src/main/java/com/example/shoppingmall/domain/item/dto/ItemDetailResponse.java
@@ -2,13 +2,18 @@ package com.example.shoppingmall.domain.item.dto;
 
 import com.example.shoppingmall.domain.item.domain.Item;
 import com.example.shoppingmall.domain.item.domain.ItemImage;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+@AllArgsConstructor
+@Builder
 @Getter
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class ItemDetailResponse {
@@ -22,7 +27,10 @@ public class ItemDetailResponse {
     private long sellerId;
     private String sellerNickname;
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm")
     private LocalDateTime createdAt;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm")
     private LocalDateTime expiredAt;
 
     private List<ItemImageResponse> itemImageList;

--- a/src/main/java/com/example/shoppingmall/domain/item/dto/ItemDetailResponse.java
+++ b/src/main/java/com/example/shoppingmall/domain/item/dto/ItemDetailResponse.java
@@ -1,0 +1,44 @@
+package com.example.shoppingmall.domain.item.dto;
+
+import com.example.shoppingmall.domain.item.domain.Item;
+import com.example.shoppingmall.domain.item.domain.ItemImage;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ItemDetailResponse {
+
+    private long itemId;
+    private String itemName;
+    private int itemPrice;
+    private String description;
+    private long hits;
+
+    private long sellerId;
+    private String sellerNickname;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime expiredAt;
+
+    private List<ItemImageResponse> itemImageList;
+    private List<StockResponse> stockList;
+
+    public ItemDetailResponse(Item item, List<ItemImage> itemImageList) {
+        this.itemId = item.getId();
+        this.itemName = item.getName();
+        this.itemPrice = item.getPrice();
+        this.description = item.getDescription();
+        this.hits = item.getHitCount();
+        this.sellerId = item.getUser().getId();
+        this.sellerNickname = item.getUser().getNickname();
+        this.createdAt = item.getCreatedAt();
+        this.expiredAt = item.getExpiredAt();
+        this.itemImageList = itemImageList.stream().map(ItemImageResponse::new).toList();
+        this.stockList = item.getStocks().stream().map(StockResponse::new).toList();
+    }
+}

--- a/src/main/java/com/example/shoppingmall/domain/item/dto/ItemImageResponse.java
+++ b/src/main/java/com/example/shoppingmall/domain/item/dto/ItemImageResponse.java
@@ -1,8 +1,10 @@
 package com.example.shoppingmall.domain.item.dto;
 
 import com.example.shoppingmall.domain.item.domain.ItemImage;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+@AllArgsConstructor
 @Getter
 public class ItemImageResponse {
 

--- a/src/main/java/com/example/shoppingmall/domain/item/dto/ItemImageResponse.java
+++ b/src/main/java/com/example/shoppingmall/domain/item/dto/ItemImageResponse.java
@@ -1,0 +1,16 @@
+package com.example.shoppingmall.domain.item.dto;
+
+import com.example.shoppingmall.domain.item.domain.ItemImage;
+import lombok.Getter;
+
+@Getter
+public class ItemImageResponse {
+
+    private long imageUrlId;
+    private String imageUrl;
+
+    public ItemImageResponse(ItemImage image) {
+        this.imageUrlId = image.getId();
+        this.imageUrl = image.getImageUrl();
+    }
+}

--- a/src/main/java/com/example/shoppingmall/domain/item/dto/ItemResponse.java
+++ b/src/main/java/com/example/shoppingmall/domain/item/dto/ItemResponse.java
@@ -1,0 +1,27 @@
+package com.example.shoppingmall.domain.item.dto;
+
+import com.example.shoppingmall.domain.item.domain.Item;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+
+
+@Getter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ItemResponse {
+
+    private long itemId;
+    private String itemName;
+    private int price;
+    private String thumbnailUrl;
+    private long hits;
+
+
+    public ItemResponse (Item item) {
+        this.itemId = item.getId();
+        this.itemName = item.getName();
+        this.price = item.getPrice();
+        this.thumbnailUrl = item.getThumbnailUrl();
+        this.hits = item.getHitCount();
+    }
+}

--- a/src/main/java/com/example/shoppingmall/domain/item/dto/StockResponse.java
+++ b/src/main/java/com/example/shoppingmall/domain/item/dto/StockResponse.java
@@ -1,0 +1,17 @@
+package com.example.shoppingmall.domain.item.dto;
+
+import com.example.shoppingmall.domain.item.domain.ItemStock;
+import com.example.shoppingmall.domain.item.type.ClothingSize;
+import lombok.Getter;
+
+@Getter
+public class StockResponse {
+
+    private ClothingSize size;
+    private int stock;
+
+    public StockResponse(ItemStock stock) {
+        this.size = stock.getSize();
+        this.stock = stock.getStock();
+    }
+}

--- a/src/main/java/com/example/shoppingmall/domain/item/dto/StockResponse.java
+++ b/src/main/java/com/example/shoppingmall/domain/item/dto/StockResponse.java
@@ -2,8 +2,10 @@ package com.example.shoppingmall.domain.item.dto;
 
 import com.example.shoppingmall.domain.item.domain.ItemStock;
 import com.example.shoppingmall.domain.item.type.ClothingSize;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+@AllArgsConstructor
 @Getter
 public class StockResponse {
 

--- a/src/main/java/com/example/shoppingmall/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/shoppingmall/global/exception/ErrorCode.java
@@ -10,9 +10,9 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 @AllArgsConstructor
 public enum ErrorCode {
 
-    temporarily(null, null),
+    //ItemException
+    NOT_FOUND_ITEM(NOT_FOUND, "물품을 찾을 수 없습니다."),
     ;
-
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/test/java/com/example/shoppingmall/domain/item/api/ItemControllerTest.java
+++ b/src/test/java/com/example/shoppingmall/domain/item/api/ItemControllerTest.java
@@ -1,0 +1,110 @@
+package com.example.shoppingmall.domain.item.api;
+
+import com.example.shoppingmall.domain.item.application.ItemService;
+import com.example.shoppingmall.domain.item.dto.ItemDetailResponse;
+import com.example.shoppingmall.domain.item.dto.ItemImageResponse;
+import com.example.shoppingmall.domain.item.dto.StockResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.example.shoppingmall.domain.item.type.ClothingSize.L;
+import static com.example.shoppingmall.domain.item.type.ClothingSize.M;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class ItemControllerTest {
+
+    @InjectMocks
+    private ItemController itemController;
+
+    @Mock
+    private ItemService itemService;
+
+    private MockMvc mockMvc;
+    private ObjectMapper objectMapper;
+
+
+    @BeforeEach
+    void init() {
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        //objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        //objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // 배열 형식 대신 ISO 형식 사용
+
+        mockMvc = MockMvcBuilders.standaloneSetup(itemController).build();
+    }
+
+    @Test
+    void getItemDetail() throws Exception {
+
+        // when
+        long itemId = 1L;
+
+        List<ItemImageResponse> itemImageResponses = List.of(
+                new ItemImageResponse(1, "이미지1"),
+                new ItemImageResponse(1, "이미지2"));
+
+        List<StockResponse> StockResponses = List.of(
+                new StockResponse(M, 2),
+                new StockResponse(L, 1));
+
+        ItemDetailResponse res = ItemDetailResponse.builder()
+                .itemId(itemId)
+                .itemName("황금바지")
+                .itemPrice(100000)
+                .description("당신도 입을 수 있어요!")
+                .hits(0)
+                .sellerId(1)
+                .sellerNickname("판매자1")
+                .createdAt(LocalDateTime.of(2024,5,10,0,0,0))
+                .expiredAt(LocalDateTime.of(2024,10,1,0,0,0))
+                .itemImageList(itemImageResponses)
+                .stockList(StockResponses)
+                .build();
+
+        when(itemService.getItemDetail(itemId)).thenReturn(res);
+
+
+        // perform: POST 요청을 보내고 결과를 검증
+        ResultActions resultActions = mockMvc.perform(get("/items/1")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(res))); // JSON 요청 바디 설정
+
+        // then: 응답 상태 및 반환된 JSON 필드 검증
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.item_id").value(itemId))
+                .andExpect(jsonPath("$.item_name").value(res.getItemName()))
+                .andExpect(jsonPath("$.item_price").value(res.getItemPrice()))
+                .andExpect(jsonPath("$.description").value(res.getDescription()))
+                .andExpect(jsonPath("$.hits").value(res.getHits()))
+                .andExpect(jsonPath("$.seller_id").value(res.getSellerId()))
+                .andExpect(jsonPath("$.seller_nickname").value(res.getSellerNickname()))
+                .andExpect(jsonPath("$.created_at").value(String.valueOf(res.getCreatedAt()).trim()))
+                .andExpect(jsonPath("$.expired_at").value(String.valueOf(res.getExpiredAt()).trim()))
+
+                .andExpect(jsonPath("$.item_image_list").isArray()) // 배열인지 검증
+                .andExpect(jsonPath("$.item_image_list.length()").value(2)) // 배열 사이즈가 동일한지
+
+                .andExpect(jsonPath("$.stock_list").isArray())
+                .andExpect(jsonPath("$.stock_list.length()").value(2));
+
+    }
+}

--- a/src/test/java/com/example/shoppingmall/domain/item/application/ItemServiceTest.java
+++ b/src/test/java/com/example/shoppingmall/domain/item/application/ItemServiceTest.java
@@ -1,0 +1,135 @@
+package com.example.shoppingmall.domain.item.application;
+
+import com.example.shoppingmall.domain.item.dao.ImageRepository;
+import com.example.shoppingmall.domain.item.dao.ItemRepository;
+import com.example.shoppingmall.domain.item.domain.Item;
+import com.example.shoppingmall.domain.item.domain.ItemImage;
+import com.example.shoppingmall.domain.item.dto.ItemDetailResponse;
+import com.example.shoppingmall.domain.item.excepction.ItemException;
+import com.example.shoppingmall.domain.user.domain.Address;
+import com.example.shoppingmall.domain.user.domain.User;
+import com.example.shoppingmall.domain.user.type.Gender;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.example.shoppingmall.domain.item.type.ClothingSize.*;
+import static com.example.shoppingmall.global.exception.ErrorCode.NOT_FOUND_ITEM;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ItemServiceTest {
+
+    @Mock
+    private ItemRepository itemRepository;
+    @Mock
+    private ImageRepository imageRepository;
+
+    @InjectMocks
+    private ItemService itemService;
+
+
+    private User user;
+    private List<Item> items;
+    private List<ItemImage> itemImages;
+
+
+    @BeforeEach
+    public void init() {
+
+        user = User.builder()
+                .id(1L)
+                .email("example@gmail.com")
+                .name("홍길동")
+                .nickname("길동이")
+                .password("mypass1234")
+                .gender(Gender.MALE)
+                .phoneNumber("010-1234-1234")
+                .address(Address.builder()
+                        .street("강남대로 123")
+                        .city("서울 특별시 강남구")
+                        .zipcode("1101").build())
+                .build();
+
+        Item item1 = Item.builder()
+                .id(1L)
+                .user(user)
+                .name("황금바지")
+                .price(10000000)
+                .thumbnailUrl("황금바지 썸네일")
+                .expiredAt(LocalDateTime.of(2024, 10, 20, 0, 0))
+                .hitCount(0L)
+                .description("당신도 입을 수 있어요!")
+                .stocks(new ArrayList<>())
+                .images(new ArrayList<>())
+                .build();
+
+        item1.addStockOption(S, 4);
+        item1.addStockOption(L, 3);
+        item1.addStockOption(XL, 2);
+
+        itemImages = new ArrayList<>();
+        itemImages.add(new ItemImage(1L, item1, "황금바지 이미지1"));
+        itemImages.add(new ItemImage(2L, item1, "황금바지 이미지2"));
+        itemImages.add(new ItemImage(3L, item1, "황금바지 이미지3"));
+
+        for (ItemImage itemImage : itemImages) {
+            item1.addImage(itemImage.getImageUrl());
+        }
+
+        items = new ArrayList<>();
+        items.add(item1);
+    }
+
+    @Test
+    void getItemDetail_Success() {
+
+        // given
+        Item item = items.get(0);
+
+        // then
+        when(itemRepository.findItemAndStockAndSeller(item.getId()))
+                .thenReturn(Optional.of(item));
+
+        when(imageRepository.findAllByItemId(item.getId()))
+                .thenReturn(itemImages);
+
+        // then
+        ItemDetailResponse response = itemService.getItemDetail(item.getId());
+
+        assertThat(response.getItemId()).isEqualTo(item.getId());
+        assertThat(response.getItemName()).isEqualTo(item.getName());
+        assertThat(response.getItemPrice()).isEqualTo(item.getPrice());
+        assertThat(response.getDescription()).isEqualTo(item.getDescription());
+        assertThat(response.getHits()).isEqualTo(item.getHitCount());
+
+        assertThat(response.getCreatedAt()).isEqualTo(item.getCreatedAt());
+        assertThat(response.getExpiredAt()).isEqualTo(item.getExpiredAt());
+
+        assertThat(response.getSellerId()).isEqualTo(item.getUser().getId());
+        assertThat(response.getSellerNickname()).isEqualTo(item.getUser().getNickname());
+
+        assertThat(response.getStockList().size()).isEqualTo(item.getStocks().size());
+        assertThat(response.getItemImageList().size()).isEqualTo(itemImages.size());
+    }
+
+    @Test
+    void getItemDetail_Fail() {
+
+        when(itemRepository.findItemAndStockAndSeller(any()))
+                .thenThrow(new ItemException(NOT_FOUND_ITEM));
+
+        assertThrows(ItemException.class, () -> itemService.getItemDetail(-1L));
+    }
+}

--- a/src/test/java/com/example/shoppingmall/domain/item/dao/ItemRepositoryTest.java
+++ b/src/test/java/com/example/shoppingmall/domain/item/dao/ItemRepositoryTest.java
@@ -1,0 +1,102 @@
+package com.example.shoppingmall.domain.item.dao;
+
+import com.example.shoppingmall.domain.item.domain.Item;
+import com.example.shoppingmall.domain.item.domain.ItemStock;
+import com.example.shoppingmall.domain.user.dao.UserRepository;
+import com.example.shoppingmall.domain.user.domain.Address;
+import com.example.shoppingmall.domain.user.domain.User;
+import com.example.shoppingmall.domain.user.type.Gender;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.example.shoppingmall.domain.item.type.ClothingSize.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+//@Rollback(value = false)
+//@SpringBootTest
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class ItemRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ItemRepository itemRepository;
+
+    private User user;
+    private List<Item> items;
+
+
+    @BeforeEach
+    public void init() {
+        items = new ArrayList<>();
+
+        Address address = Address.builder()
+                .street("강남대로 123")
+                .city("서울 특별시 강남구")
+                .zipcode("1101").build();
+
+        user = User.builder()
+                .email("example@gmail.com")
+                .name("홍길동")
+                .nickname("길동이")
+                .password("mypass1234")
+                .gender(Gender.MALE)
+                .phoneNumber("010-1234-1234")
+                .address(address).build();
+
+        userRepository.save(user);
+
+
+        Item item1 = Item.builder()
+                .user(user)
+                .name("황금바지")
+                .price(10000000)
+                .thumbnailUrl("황금바지 썸네일")
+                .expiredAt(LocalDateTime.of(2024, 10, 20, 0, 0))
+                .hitCount(0L)
+                .description("당신도 입을 수 있어요!")
+                .stocks(new ArrayList<>())
+                .images(new ArrayList<>())
+                .build();
+
+        item1.addStockOption(S, 4);
+        item1.addStockOption(L, 3);
+        item1.addStockOption(XL, 2);
+
+        items.add(item1);
+        itemRepository.saveAll(items);
+    }
+
+    @DisplayName("물품정보와 해당물품에 속한 옵션들(사이즈&재고)과 판매자 정보를 한번에 가져옵니다.")
+    @Test
+    void findItemAndStockAndSeller() {
+        Item savedItem = items.get(0);
+
+        Item itemAndStockAndSeller = itemRepository.findItemAndStockAndSeller(savedItem.getId()).get();
+
+        assertThat(itemAndStockAndSeller).isNotNull();
+
+        assertThat(itemAndStockAndSeller.getId()).isEqualTo(savedItem.getId());
+        assertThat(itemAndStockAndSeller.getName()).isEqualTo(savedItem.getName());
+        assertThat(itemAndStockAndSeller.getPrice()).isEqualTo(savedItem.getPrice());
+
+        assertThat(itemAndStockAndSeller.getThumbnailUrl()).isEqualTo(savedItem.getThumbnailUrl());
+        assertThat(itemAndStockAndSeller.getExpiredAt()).isEqualTo(savedItem.getExpiredAt());
+        assertThat(itemAndStockAndSeller.getDescription()).isEqualTo(savedItem.getDescription());
+
+        List<ItemStock> stocks = itemAndStockAndSeller.getStocks();
+
+        assertThat(stocks.size()).isEqualTo(savedItem.getStocks().size());
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용

~~- [ ] 물품목록 조회 기능 구현~~
- [x] 물품 상세정보 조회 기능 구현
- [x] api 테스트
- [x] 테스트코드

-  먼저 구현했던 물품 일반 조회는 삭제하였음 (후에 구현할 검색 api 로 재사용할 수 있다고 판단)
- 물품 상세 조회 (과정)
  - 물품 상세조회 시에 [category], [user], [item_image], [item_stock] 테이블의 정보들이 필요하였음
  - 구현 계획 중에 카테고리는 굳이 필요 없을 듯 하다고 판단하여 제외
  -  성능문제 (N+1) 때문에 양방향 매핑을 한 뒤 패치조인을 통해 데이터를 가져오려 하였음
  -  다중 패치 조인이 가능하지만 컬렉션을 둘 이상 패치조인 할 수 없었음 (컬렉션이 아닌 경우 상관없음)
  - 패치조인으로 [**item**]  -  [**user**  (manyToOne)] [**item_stock** (oneToMany)]  로 가져오게끔하였음
    -  findItemAndStockAndSeller 메서드
  - 같이 가져오지 못한  [item_image] 는 별도로  ImageRepository를 통해 findAllByItemId 를 통해 가져왔음 (다시 한번 item과의 패치조인으로 해결하는 것보다 성능상 더 낫지 않을까 판단함)

결론 :
 -   [**item**]  -  [**user**  (manyToOne)] [**item_stock** (oneToMany)]  다중조인패치 1번  + 이미지는 item id 값 기반으로 일반조회 1번
- 2번의 쿼리문이 나가는 형태로 구현함
  <br/>

## 이미지 첨부
![image](https://github.com/user-attachments/assets/de3858f8-e357-4e84-9ef9-9ae2a10107d0)

<!--<img src="파일주소" width="50%" height="50%"/>-->

<br/>

## 🔧 리뷰 요구사항
> 혹시 더 나은 방법이 있다고 생각하신다면 의견을 내주세요. 나중에 리팩토링 해보겠습니다. 


<br/>
closes #8