### PR TITLE
✨feat: 판매 상품 이미지 등록 기능 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,11 @@ dependencies {
     clean {
         delete file('src/main/generated')
     }
-    
+
+    // s3 기능 추가
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.1'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/shoppingmall/domain/item/api/ItemController.java
+++ b/src/main/java/com/example/shoppingmall/domain/item/api/ItemController.java
@@ -1,12 +1,14 @@
 package com.example.shoppingmall.domain.item.api;
 
 import com.example.shoppingmall.domain.item.application.ItemService;
+import com.example.shoppingmall.domain.item.application.S3Service;
 import com.example.shoppingmall.domain.item.dto.ItemDetailResponse;
-import com.example.shoppingmall.domain.item.dto.ItemResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -14,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 public class ItemController {
 
     private final ItemService itemService;
-
+    private final S3Service s3Service;
 
     @GetMapping("/{item_id}")
     public ResponseEntity<ItemDetailResponse> getItemDetail(
@@ -22,4 +24,13 @@ public class ItemController {
 
         return ResponseEntity.ok(itemService.getItemDetail(itemId));
     }
+
+    // 이미지 업로드
+    @PostMapping("/images/upload")
+    public ResponseEntity<List<String>> getResignedUrls(@RequestParam("images") List<MultipartFile> multipartFiles) {
+        List<String> urls = s3Service.createUrlsForUpload(multipartFiles);
+        return ResponseEntity.ok(urls);
+    }
+
+
 }

--- a/src/main/java/com/example/shoppingmall/domain/item/application/S3Service.java
+++ b/src/main/java/com/example/shoppingmall/domain/item/application/S3Service.java
@@ -61,8 +61,7 @@ public class S3Service {
 
     private String uploadValidation(MultipartFile file) {
 
-        // 1. 파일 이름이 동일할 경우 UUID를 통해 고유 키를 나눠주고
-        // 이미지를 하나이상은 등록하게 설정
+        // 1. 파일 이름이 동일할 경우를 대비해서 UUID 에서 생성된 키와 함께 S3에 저장
         String uniqueFileName = Optional.of(file)
                 .filter(f -> !f.isEmpty())
                 .map(f -> {

--- a/src/main/java/com/example/shoppingmall/domain/item/application/S3Service.java
+++ b/src/main/java/com/example/shoppingmall/domain/item/application/S3Service.java
@@ -1,0 +1,128 @@
+package com.example.shoppingmall.domain.item.application;
+
+import com.example.shoppingmall.domain.item.excepction.S3Exception;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.Duration;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static com.example.shoppingmall.global.exception.ErrorCode.*;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucket;
+    private final S3Presigner s3Presigner;
+    private final S3Client s3Client;
+    private final List<String> allowedExtensions = Arrays.asList("jpg", "jpeg", "png");
+    private final long maxFileSize = 1_000_000;
+
+    public List<String> createUrlsForUpload(List<MultipartFile> files) {
+
+        // 파일 수를 체크
+        if (files.size() > 3) throw new S3Exception(MAX_UPLOAD_LIMIT);
+
+        return files.stream()
+                .map(this::uploadValidation)
+                .collect(Collectors.toList());
+    }
+
+    public void urlForUpdate(MultipartFile oldFile, MultipartFile newFile) {
+        urlForDelete(oldFile);
+        createUrlsForUpload(Collections.singletonList(newFile));
+    }
+
+    // 이미지 삭제를 위한 메서드
+    public void urlForDelete(MultipartFile file) {
+        Optional.ofNullable(file.getOriginalFilename())
+                .map(this::extractKeyFromUrl) // URL에서 키를 추출
+                .ifPresentOrElse(imagePath -> {
+                    // 경로가 존재하는 경우
+                    DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                            .bucket(bucket)
+                            .key(imagePath)
+                            .build();
+                    s3Client.deleteObject(deleteObjectRequest);
+                }, () -> { throw new S3Exception(NOT_VALID_URL); });
+    }
+
+    private String uploadValidation(MultipartFile file) {
+
+        // 1. 파일 이름이 동일할 경우 UUID를 통해 고유 키를 나눠주고
+        // 이미지를 하나이상은 등록하게 설정
+        String uniqueFileName = Optional.of(file)
+                .filter(f -> !f.isEmpty())
+                .map(f -> {
+                    String uuid = UUID.randomUUID().toString();
+                    return uuid + "_" + f.getOriginalFilename();
+                })
+                .orElseThrow(() -> new S3Exception(NOT_ENOUGH_IMAGES));
+
+        // 2. 이미지 확장자 확인
+        checkImageExtension(file.getOriginalFilename());
+
+        // 3. 이미지 크기 확인 = 1MB
+        checkFileSize(file.getSize());
+
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key("test/" + uniqueFileName)
+                .build();
+
+        PutObjectPresignRequest preSignRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(3))
+                .putObjectRequest(putObjectRequest)
+                .build();
+
+        return s3Presigner.presignPutObject(preSignRequest).url().toString();
+    }
+
+    private void checkImageExtension(String originalFileName) {
+        Optional.ofNullable(originalFileName)
+                .filter(f -> !f.isEmpty())
+                .map(f -> f.substring(f.lastIndexOf(".") + 1).toLowerCase()) // 확장자 추출
+                .filter(allowedExtensions::contains) // 허용된 확장자인지 검사
+                .orElseThrow(() -> new S3Exception(INVALID_IMAGE_TYPE));
+    }
+
+    private void checkFileSize(long fileSize) {
+        Optional.of(fileSize)
+                .filter((f) -> f < maxFileSize)
+                .orElseThrow(() -> new S3Exception(IMAGE_TOO_LARGE));
+    }
+
+    private String extractKeyFromUrl(String url) {
+        return Optional.ofNullable(url) // url이 null이 아닐 경우 Optional 생성
+                .filter(this::isValidUrl) // URL이 유효한 경우만 필터링
+                .map(this::getPathFromUrl)
+                .orElseThrow(() -> new S3Exception(NOT_FOUND_IMAGE_URL));
+    }
+
+    private boolean isValidUrl(String url) {
+        // URL 형식 검증
+        return url.matches("^(http|https)://.*$");
+    }
+
+    // 유효한 URL에서 경로를 추출하는 메서드
+    private String getPathFromUrl(String url) {
+        try {
+            return new URL(url).getPath().substring(1); // URL에서 '/'를 제거하여 키를 추출
+        } catch (MalformedURLException e) {
+            throw new S3Exception(INVALID_URL_FORMAT); // 잘못된 URL 형식일 경우 예외 발생
+        }
+    }
+
+}

--- a/src/main/java/com/example/shoppingmall/domain/item/excepction/S3Exception.java
+++ b/src/main/java/com/example/shoppingmall/domain/item/excepction/S3Exception.java
@@ -1,0 +1,13 @@
+package com.example.shoppingmall.domain.item.excepction;
+
+import com.example.shoppingmall.global.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class S3Exception extends RuntimeException {
+    private final ErrorCode errorCode;
+    public S3Exception(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/example/shoppingmall/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/shoppingmall/global/exception/ErrorCode.java
@@ -14,9 +14,18 @@ public enum ErrorCode {
     ALREADY_EXIST_USER(CONFLICT,"이미 존재하는 사용자입니다."),
     CREATE_USER_FAILED(INTERNAL_SERVER_ERROR,"회원가입에 실패했습니다."),
 
-
     //ItemException
     NOT_FOUND_ITEM(NOT_FOUND, "물품을 찾을 수 없습니다."),
+
+    //S3Exception
+    INVALID_IMAGE_TYPE(BAD_REQUEST, "허용되지 않는 파일 형식입니다. JPEG, JPG, PNG 파일만 가능합니다."),
+    IMAGE_TOO_LARGE(PAYLOAD_TOO_LARGE, "파일 크기가 1MB를 초과합니다."),
+    NOT_FOUND_IMAGE_URL(NOT_FOUND,"해당 사진의 주소가 존재 하지 않습니다."),
+    NOT_VALID_URL(NOT_FOUND,"잘못된 URL 형태입니다."),
+    NOT_ENOUGH_IMAGES(NOT_FOUND,"최소 1장의 이미지를 업로드해야 합니다."),
+    MAX_UPLOAD_LIMIT(NOT_FOUND,"최대 3장 까지만 업로드가 가능합니다."),
+    INVALID_URL_FORMAT(NOT_FOUND,"잘못된 URL 형식입니다.")
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,23 +7,33 @@ spring:
     import: optional:file:.env[.properties]
 ---
 spring:
-   config:
-     activate:
-       on-profile: local
-   datasource:
+  config:
+    activate:
+      on-profile: local
+  datasource:
     driver-class-name: ${DB_DRIVER}
     url: ${DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
 
-   jpa:
-     hibernate:
-       ddl-auto: create
-     show-sql: true
-     properties:
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
       hibernate:
         format_sql: true
-     open-in-view: false
+    open-in-view: false
+
+  cloud:
+    aws:
+      credentials:
+        accessKey: ${ACCESSKEY}
+        secretKey: ${SECRETKEY}
+      s3:
+        bucket: ${BUCKET}
+      region:
+        static: ${STATIC_REGION}
 
 logging:
   level:


### PR DESCRIPTION
## 🔎 작업 내용

- 파일 이름이 동일할 경우 UUID를 통해 고유 키를 생성해서 구분짓기로 결정했습니다.

- 이미지 확장자(jpg, jpeg, png)만 등록 가능하게 제어 했습니다.

- 이미지는 최대 3개까지 등록하게 제어 했고 1개는 반드시 등록하도록 제어 했습니다.

- 이미지 크기는 일단은 1MB로 제한 하여 보다 큰 사진은 등록하지 못하게 제어 했습니다.


## 📋 전달사항
- 노션에 .env 파일을 공유하였으니 필히 추가해주세요!

closes #28 
