### PR TITLE
🐛Fix(user):로그인,회원가입,로그아웃 수정

### DIFF
--- a/src/main/java/com/example/shoppingmall/TestDataInit_SearchItems.java
+++ b/src/main/java/com/example/shoppingmall/TestDataInit_SearchItems.java
@@ -46,8 +46,7 @@ public class TestDataInit_SearchItems {
 
         // 유저 ===================================================
         Address address = Address.builder()
-                .street("강남대로 123")
-                .city("서울 특별시 강남구")
+                .city("서울 특별시 강남구 강남대로 123")
                 .zipcode("1101").build();
 
         User user = userRepository.save(User.builder()

--- a/src/main/java/com/example/shoppingmall/domain/user/domain/Address.java
+++ b/src/main/java/com/example/shoppingmall/domain/user/domain/Address.java
@@ -14,7 +14,6 @@ import lombok.NoArgsConstructor;
 public class Address {
 
     private String city;
-    private String street;
     private String zipcode;
 }
 

--- a/src/main/java/com/example/shoppingmall/domain/user/dto/AddressRequest.java
+++ b/src/main/java/com/example/shoppingmall/domain/user/dto/AddressRequest.java
@@ -12,9 +12,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class AddressRequest {
 
-    @NotBlank(message = "도로명 주소를 입력해주세요.")
-    private String street;
-    @NotBlank(message = "시/군/구 주소를 입력해주세요.")
+    @NotBlank(message = "주소를 입력해주세요.")
     private String city;
     @NotBlank(message = "우편번호를 입력해주세요.")
     private String zipcode;

--- a/src/main/java/com/example/shoppingmall/domain/user/dto/LoginRequest.java
+++ b/src/main/java/com/example/shoppingmall/domain/user/dto/LoginRequest.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class SigninRequest {
+public class LoginRequest {
     @NotBlank(message = "이메일은 필수 입력 값입니다.")
     @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}$",
             message = "이메일 형식이 올바르지 않습니다.")

--- a/src/main/java/com/example/shoppingmall/domain/user/dto/SignupRequest.java
+++ b/src/main/java/com/example/shoppingmall/domain/user/dto/SignupRequest.java
@@ -50,7 +50,6 @@ public class SignupRequest {
                 .email(email).name(name).nickname(nickname)
                 .password(encodedPwd).gender(gender).phoneNumber(phoneNumber)
                 .address(Address.builder()
-                        .street(address.getStreet())
                         .city(address.getCity())
                         .zipcode(address.getZipcode()).build())
                 .build();

--- a/src/main/java/com/example/shoppingmall/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/shoppingmall/global/config/SecurityConfig.java
@@ -63,8 +63,11 @@ public class SecurityConfig {
 
 
         http.authorizeHttpRequests(auth-> auth
-                .requestMatchers("users/signup","users/signin",
-                        "/","users/check-email").permitAll()
+                .requestMatchers(
+                        "/",
+                        "users/signup",
+                        "users/login",
+                        "users/check-email").permitAll()
                 .anyRequest().authenticated());
 
 

--- a/src/main/java/com/example/shoppingmall/global/security/detail/CustomUserDetailService.java
+++ b/src/main/java/com/example/shoppingmall/global/security/detail/CustomUserDetailService.java
@@ -19,6 +19,6 @@ public class CustomUserDetailService implements UserDetailsService {
     public CustomUserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
-        return new CustomUserDetails(UserDetailsDTO.toUserEntity(user));
+        return new CustomUserDetails(UserDetailsDTO.from(user));
     }
 }

--- a/src/main/java/com/example/shoppingmall/global/security/dto/UserDetailsDTO.java
+++ b/src/main/java/com/example/shoppingmall/global/security/dto/UserDetailsDTO.java
@@ -15,7 +15,7 @@ public class UserDetailsDTO {
     private String password;
     private String role;
 
-    public static UserDetailsDTO toUserEntity(User user){
+    public static UserDetailsDTO from(User user){
         return UserDetailsDTO.builder()
                 .email(user.getEmail())
                 .password(user.getPassword())

--- a/src/main/java/com/example/shoppingmall/global/security/filter/CustomLogoutFilter.java
+++ b/src/main/java/com/example/shoppingmall/global/security/filter/CustomLogoutFilter.java
@@ -27,7 +27,7 @@ public class CustomLogoutFilter extends GenericFilterBean {
     private void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException{
         String requestUri = request.getRequestURI();
 
-        if (!requestUri.matches("^||/users/signout$")){
+        if (!requestUri.matches("^||/users/logout$")){
             filterChain.doFilter(request,response);
             return;
         }

--- a/src/main/java/com/example/shoppingmall/global/security/filter/LoginFilter.java
+++ b/src/main/java/com/example/shoppingmall/global/security/filter/LoginFilter.java
@@ -33,12 +33,20 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         this.jwtUtil = jwtUtil;
         this.redisAuthUtil = redisAuthUtil;
         this.authenticationManager = authenticationManager;
-        setFilterProcessesUrl("/users/signin");
+        setFilterProcessesUrl("/users/login");
     }
 
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+
         try {
+            if (!request.getMethod().equals("POST")){
+                response.setContentType("application/json; charset=UTF-8");
+                response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                response.getWriter().write("{\"message\":\"요청 메소드가 올바르지 않습니다.\"}");
+                return null;
+            }
+
             ObjectMapper objectMapper = new ObjectMapper();
             LoginRequest loginRequest = objectMapper.readValue(request.getInputStream(), LoginRequest.class);
             String email = loginRequest.getEmail();

--- a/src/main/java/com/example/shoppingmall/global/security/filter/LoginFilter.java
+++ b/src/main/java/com/example/shoppingmall/global/security/filter/LoginFilter.java
@@ -1,6 +1,6 @@
 package com.example.shoppingmall.global.security.filter;
 
-import com.example.shoppingmall.domain.user.dto.SigninRequest;
+import com.example.shoppingmall.domain.user.dto.LoginRequest;
 import com.example.shoppingmall.global.security.detail.CustomUserDetails;
 import com.example.shoppingmall.global.security.util.JwtUtil;
 import com.example.shoppingmall.global.security.util.RedisAuthUtil;
@@ -40,9 +40,9 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
         try {
             ObjectMapper objectMapper = new ObjectMapper();
-            SigninRequest signinRequest = objectMapper.readValue(request.getInputStream(), SigninRequest.class);
-            String email = signinRequest.getEmail();
-            String password = signinRequest.getPassword();
+            LoginRequest loginRequest = objectMapper.readValue(request.getInputStream(), LoginRequest.class);
+            String email = loginRequest.getEmail();
+            String password = loginRequest.getPassword();
 
             if (!isEmailValid(email)) {
                 response.setContentType("application/json; charset=UTF-8");

--- a/src/test/java/com/example/shoppingmall/domain/item/application/ItemServiceTest.java
+++ b/src/test/java/com/example/shoppingmall/domain/item/application/ItemServiceTest.java
@@ -57,8 +57,7 @@ class ItemServiceTest {
                 .gender(Gender.MALE)
                 .phoneNumber("010-1234-1234")
                 .address(Address.builder()
-                        .street("강남대로 123")
-                        .city("서울 특별시 강남구")
+                        .city("서울 특별시 강남구 강남대로 123")
                         .zipcode("1101").build())
                 .build();
 

--- a/src/test/java/com/example/shoppingmall/domain/item/dao/ItemRepositoryTest.java
+++ b/src/test/java/com/example/shoppingmall/domain/item/dao/ItemRepositoryTest.java
@@ -57,8 +57,7 @@ class ItemRepositoryTest {
         items = new ArrayList<>();
 
         Address address = Address.builder()
-                .street("강남대로 123")
-                .city("서울 특별시 강남구")
+                .city("서울 특별시 강남구 강남대로 123")
                 .zipcode("1101").build();
 
         user = User.builder()

--- a/src/test/java/com/example/shoppingmall/domain/user/api/UserControllerTest.java
+++ b/src/test/java/com/example/shoppingmall/domain/user/api/UserControllerTest.java
@@ -2,11 +2,7 @@ package com.example.shoppingmall.domain.user.api;
 
 import com.example.shoppingmall.domain.user.application.UserService;
 import com.example.shoppingmall.domain.user.dto.*;
-import com.example.shoppingmall.domain.user.excepction.UserException;
 import com.example.shoppingmall.domain.user.type.Gender;
-import com.example.shoppingmall.global.exception.ErrorCode;
-import com.example.shoppingmall.global.exception.ErrorResult;
-import com.example.shoppingmall.global.exception.GlobalExceptionHandler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -15,7 +11,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -47,8 +42,7 @@ class UserControllerTest {
         objectMapper = new ObjectMapper();
         mockMvc = MockMvcBuilders.standaloneSetup(userController).build();
         AddressRequest addressRequest = AddressRequest.builder()
-                .street("강남대로 123")
-                .city("서울 특별시 강남구")
+                .city("서울 특별시 강남구 강남대로 123")
                 .zipcode("1010").build();
         signupRequest = SignupRequest.builder()
                 .email("example@gmail.com")

--- a/src/test/java/com/example/shoppingmall/domain/user/application/UserServiceTest.java
+++ b/src/test/java/com/example/shoppingmall/domain/user/application/UserServiceTest.java
@@ -16,9 +16,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
-import java.util.Map;
-import java.util.Optional;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -47,12 +44,10 @@ class UserServiceTest {
         String correctPwd = "example1234";
         String correctPhone = "010-1234-1234";
         AddressRequest addressRequest = AddressRequest.builder()
-                .street("강남대로 123")
-                .city("서울 특별시 강남구")
+                .city("서울 특별시 강남구 강남대로 123")
                 .zipcode("1010").build();
         Address address = Address.builder()
-                .street("강남대로 123")
-                .city("서울 특별시 강남구")
+                .city("서울 특별시 강남구 강남대로 123")
                 .zipcode("1010")
                 .build();
         signupRequest = SignupRequest.builder()

--- a/src/test/java/com/example/shoppingmall/domain/user/dao/UserRepositoryTest.java
+++ b/src/test/java/com/example/shoppingmall/domain/user/dao/UserRepositoryTest.java
@@ -27,8 +27,7 @@ class UserRepositoryTest {
     @BeforeEach
     public void init(){
         Address address = Address.builder()
-                .street("강남대로 123")
-                .city("서울 특별시 강남구")
+                .city("서울 특별시 강남구 강남대로 123")
                 .zipcode("1101").build();
         user = User.builder()
                 .email("example@gmail.com")


### PR DESCRIPTION


## 🔎 작업 내용

- 로그인, 로그아웃 요청 api 수정
- 로그인 필터에서 POST 메소드 이외의 메소드 요청 들어올시 500
- 회원가입 시 받는 데이터 형태 수정
- UserDetailsDTO 변환 메소드 이름 from() 으로 수정
- 위 변경사항에 따른 SecurityConfig 수정

  <br/>


<br/>

## 🔧 리뷰 요구사항
> 회원가입시 받는 주소 데이터가 세개에서 두개로 줄었으니 테스트시 확인 부탁드립니다.
> 도경님 테스트코드의 street 부분을 전부 삭제했습니다

closes #37 