### PR TITLE
✨Feat: 장바구니 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/shoppingmall/TestDataInit_Cart.java
+++ b/src/main/java/com/example/shoppingmall/TestDataInit_Cart.java
@@ -5,7 +5,7 @@ import com.example.shoppingmall.domain.item.dao.ItemRepository;
 import com.example.shoppingmall.domain.item.domain.Category;
 import com.example.shoppingmall.domain.item.domain.ClothingSize;
 import com.example.shoppingmall.domain.item.domain.Item;
-import com.example.shoppingmall.domain.item.dto.ClothingSizeRepository;
+import com.example.shoppingmall.domain.item.dao.ClothingSizeRepository;
 import com.example.shoppingmall.domain.item.type.CategoryName;
 import com.example.shoppingmall.domain.item.type.ClothingSizeName;
 import com.example.shoppingmall.domain.item.type.ItemStatus;
@@ -14,8 +14,6 @@ import com.example.shoppingmall.domain.user.domain.Address;
 import com.example.shoppingmall.domain.user.domain.User;
 import com.example.shoppingmall.domain.user.type.Gender;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.context.event.ApplicationReadyEvent;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/com/example/shoppingmall/domain/cart/api/CartController.java
+++ b/src/main/java/com/example/shoppingmall/domain/cart/api/CartController.java
@@ -2,15 +2,14 @@ package com.example.shoppingmall.domain.cart.api;
 
 import com.example.shoppingmall.domain.cart.application.CartService;
 import com.example.shoppingmall.domain.cart.dto.AddCartItemRequest;
+import com.example.shoppingmall.domain.item.dto.CartItemResponse;
 import com.example.shoppingmall.global.security.detail.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 
 @RequiredArgsConstructor
@@ -28,5 +27,14 @@ public class CartController { // TODO 정말 만약에 시간이 남는다면, �
 
         cartService.addCartItem(userDetails, request);
         return ResponseEntity.ok().build();
+    }
+
+
+    @GetMapping
+    public ResponseEntity<Slice<CartItemResponse>> getMyCartItems(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(name = "page", defaultValue = "0") int pageNumber) {
+
+        return ResponseEntity.ok(cartService.getMyCartItems(userDetails, pageNumber));
     }
 }

--- a/src/main/java/com/example/shoppingmall/domain/cart/application/CartService.java
+++ b/src/main/java/com/example/shoppingmall/domain/cart/application/CartService.java
@@ -4,9 +4,11 @@ import com.example.shoppingmall.domain.cart.dao.CartRepository;
 import com.example.shoppingmall.domain.cart.domain.Cart;
 import com.example.shoppingmall.domain.cart.domain.CartItem;
 import com.example.shoppingmall.domain.cart.dto.AddCartItemRequest;
+import com.example.shoppingmall.domain.cart.excepction.CartException;
 import com.example.shoppingmall.domain.item.dao.CartItemRepository;
 import com.example.shoppingmall.domain.item.dao.ItemStockRepository;
 import com.example.shoppingmall.domain.item.domain.ItemStock;
+import com.example.shoppingmall.domain.item.dto.CartItemResponse;
 import com.example.shoppingmall.domain.item.excepction.ItemException;
 import com.example.shoppingmall.domain.user.dao.UserRepository;
 import com.example.shoppingmall.domain.user.domain.User;
@@ -14,9 +16,11 @@ import com.example.shoppingmall.domain.user.excepction.UserException;
 import com.example.shoppingmall.global.exception.ErrorCode;
 import com.example.shoppingmall.global.security.detail.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.Optional;
 
 @Transactional
@@ -66,6 +70,30 @@ public class CartService {
                     .addCartItem(itemStock.getItem(), itemStock, request.getQuantity());
         }
 
+    }
 
+
+    /**
+     * 검색때와 마찬가지로 Pageable 로 받지 않았습니다.
+     * 현재는 잘못된 값이 들어왔을 때
+     * 서비스나 커스텀레파지토리에서 처리해서 새로운 PageRequest 를 만들어서 사용하는 방식을 취했지만,
+     * 다음 프로젝트 때 기회가 된다면
+     * Pageable 에 관련한 커스텀 예외 처리 클래스를 따로 만들어보는 방식으로 해보겠습니다.
+     */
+    public Slice<CartItemResponse> getMyCartItems(CustomUserDetails userDetails, int pageNumber) {
+
+        Long cartId = cartRepository.findCartId(userDetails.getUserId());
+        if(cartId == null || cartId == 0){
+            return new SliceImpl<>(new ArrayList<>(), PageRequest.ofSize(0), false);
+        }
+        if(--pageNumber < 0)  pageNumber = 0;
+        System.out.println("pageNumber: " +  pageNumber);
+
+        return cartItemRepository.findMyCartItems(cartId, cartPageable(pageNumber))
+                .map(CartItemResponse::from);
+    }
+
+    private Pageable cartPageable(int pageNumber) {
+        return PageRequest.of(pageNumber, 20, Sort.Direction.DESC, "createdAt");
     }
 }

--- a/src/main/java/com/example/shoppingmall/domain/cart/dao/CartRepository.java
+++ b/src/main/java/com/example/shoppingmall/domain/cart/dao/CartRepository.java
@@ -2,6 +2,8 @@ package com.example.shoppingmall.domain.cart.dao;
 
 import com.example.shoppingmall.domain.cart.domain.Cart;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -10,4 +12,7 @@ import java.util.Optional;
 public interface CartRepository extends JpaRepository<Cart, Long> {
 
     Optional<Cart> findByUserId(Long userId);
+
+    @Query("select c.id from Cart c where c.user.id = :userId")
+    Long findCartId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/shoppingmall/domain/item/dao/CartItemRepository.java
+++ b/src/main/java/com/example/shoppingmall/domain/item/dao/CartItemRepository.java
@@ -1,6 +1,8 @@
 package com.example.shoppingmall.domain.item.dao;
 
 import com.example.shoppingmall.domain.cart.domain.CartItem;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,4 +19,10 @@ public interface CartItemRepository extends JpaRepository<CartItem, Long> {
             " where ci.cart.id = :cartId and ci.itemStock.id = :itemStockId")
     Optional<CartItem> findCartItemByFetch(@Param("cartId") long cartId, @Param("itemStockId") long itemStockId);
 
+    @Query("select ci from CartItem ci " +
+            " join fetch ci.item " +
+            " join fetch ci.itemStock is " +
+            " join fetch is.clothingSize " +
+            " where ci.cart.id = :cartId")
+    Slice<CartItem> findMyCartItems(@Param("cartId") Long cartId, Pageable pageable);
 }

--- a/src/main/java/com/example/shoppingmall/domain/item/dao/ClothingSizeRepository.java
+++ b/src/main/java/com/example/shoppingmall/domain/item/dao/ClothingSizeRepository.java
@@ -1,4 +1,4 @@
-package com.example.shoppingmall.domain.item.dto;
+package com.example.shoppingmall.domain.item.dao;
 
 import com.example.shoppingmall.domain.item.domain.ClothingSize;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/example/shoppingmall/domain/item/dto/CartItemResponse.java
+++ b/src/main/java/com/example/shoppingmall/domain/item/dto/CartItemResponse.java
@@ -1,0 +1,59 @@
+package com.example.shoppingmall.domain.item.dto;
+
+import com.example.shoppingmall.domain.cart.domain.CartItem;
+import com.example.shoppingmall.domain.item.type.ClothingSizeName;
+import com.example.shoppingmall.domain.item.type.ItemStatus;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@Getter
+public class CartItemResponse {
+
+    // [cart_item]
+    private Long cartItemId;
+    private int quantity;
+
+    // [item]
+    private Long itemId;
+    private String itemName;
+    private int itemPrice;
+    private ItemStatus itemStatus;
+    private String thumbnailUrl;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm")
+    private LocalDateTime expiredAt;
+
+    // [item_stock]
+    private Long itemStockId;
+    private int currentStock;
+
+    // [clothing_size]
+    private Long clothingSizeId;
+    private ClothingSizeName sizeName;
+
+    public static CartItemResponse from(CartItem cartItem) { // 패치조인해온 CartItem
+        return CartItemResponse.builder()
+                .cartItemId(cartItem.getId())
+                .quantity(cartItem.getQuantity())
+                .itemId(cartItem.getItem().getId())
+                .itemName(cartItem.getItem().getName())
+                .itemPrice(cartItem.getItem().getPrice())
+                .itemStatus(cartItem.getItem().getStatus())
+                .thumbnailUrl(cartItem.getItem().getThumbnailUrl())
+                .expiredAt(cartItem.getItem().getExpiredAt())
+                .itemStockId(cartItem.getItemStock().getId())
+                .currentStock(cartItem.getItemStock().getStock())
+                .clothingSizeId(cartItem.getItemStock().getClothingSize().getId())
+                .sizeName(cartItem.getItemStock().getClothingSize().getSizeName())
+                .build();
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용

- **장바구니 조회 기능**
  - 인증정보에 담긴 userId를 기반으로 cartId를 찾아온다.
  - 해당 Cart에 속하는 CartItem 들을 찾아온다.
    -   [**cart_item**]   [**item**]   **[item_stock**]  [**clothing_size**] 데이터들을 패치조인하여 한번에 가져온다.
    -   페이징 처리를 위하여 slice형태로 반환
    -  모종의 이유로 장바구니가 존재하지 않는다면, 빈 slice 객체를 반환

 <br/>

## 이미지 첨부

![image](https://github.com/user-attachments/assets/d7ca578c-8e58-4602-b7e0-1dc8f77c410b)

패치 조인해온 엔티티 참고
<br/>

## 🔧 리뷰 요구사항

     검색때와 마찬가지로 Pageable 로 받지 않았습니다.
     현재는 잘못된 값이 들어왔을 때
     서비스나 커스텀레파지토리에서 처리해서 새로운 PageRequest 를 만들어서 사용하는 방식을 취했지만,
     다음 프로젝트 때 기회가 된다면
     Pageable 에 관련한 커스텀 예외 처리 클래스를 따로 만들어보는 방식으로 해보겠습니다.
    
<br/>
