### PR TITLE
✨Feat: 장바구니 물품 삭제 기능 구현

### DIFF
--- a/src/main/java/com/example/shoppingmall/domain/cart/api/CartController.java
+++ b/src/main/java/com/example/shoppingmall/domain/cart/api/CartController.java
@@ -11,6 +11,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 
 @RequiredArgsConstructor
 @RestController
@@ -48,4 +50,15 @@ public class CartController { // TODO 정말 만약에 시간이 남는다면, �
         cartService.modifyCartItemQuantity(customUserDetails, cartItemId, quantity);
         return ResponseEntity.ok().build();
     }
+
+
+    @DeleteMapping("/items")
+    public ResponseEntity<Void> deleteCartItems(
+            @RequestParam("cart_item_id") List<Long> cartItemIdList,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        cartService.deleteCartItems(cartItemIdList, userDetails);
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/src/main/java/com/example/shoppingmall/domain/cart/application/CartService.java
+++ b/src/main/java/com/example/shoppingmall/domain/cart/application/CartService.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import static com.example.shoppingmall.global.exception.ErrorCode.CART_ITEM_NOT_MODIFIABLE;
@@ -114,5 +115,10 @@ public class CartService {
         }
 
         cartItem.modifyQuantity(quantity);
+    }
+
+    @Transactional
+    public void deleteCartItems(List<Long> cartItemIdList, CustomUserDetails userDetails) {
+        cartItemRepository.deleteCartItems(cartItemIdList, userDetails.getUserId());
     }
 }

--- a/src/main/java/com/example/shoppingmall/domain/item/dao/CartItemRepository.java
+++ b/src/main/java/com/example/shoppingmall/domain/item/dao/CartItemRepository.java
@@ -4,10 +4,12 @@ import com.example.shoppingmall.domain.cart.domain.CartItem;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -33,6 +35,15 @@ public interface CartItemRepository extends JpaRepository<CartItem, Long> {
             " join fetch ci.itemStock " +
             " where ci.id = :cartItemId")
     Optional<CartItem> findCartItemByFetch(@Param("cartItemId") long cartItemId);
+
+
+
+    @Modifying
+    @Query("delete from CartItem ci " +
+            " where ci.id in :cartItemIds and " +
+            " ci.cart.user.id = :userId")
+    void deleteCartItems( @Param("cartItemIds") List<Long> cartItemIds, @Param("userId") Long userId);
+
 
 }
 


### PR DESCRIPTION
## 🔎 작업 내용

 **장바구니 물품 삭제 기능**
   - 요청으로부터 삭제하길 원하는 cart_item_id 값들을 List 로 받아온다.
   - 본인이 담은 cart_item만 삭제되어야 하므로,  인증객체로부터 꺼낸 userId를 조건에 추가한다.
      ``` 
      @Modifying
      @Query("delete from CartItem ci " +
              " where ci.id in :cartItemIds and " +
              " ci.cart.user.id = :userId")
          void deleteCartItems( @Param("cartItemIds") List<Long> cartItemIds, @Param("userId") Long userId); 
  <br/>

## 이미지 첨부 (선)

![image](https://github.com/user-attachments/assets/715d8081-d7ff-4101-b720-0bc125256d2e)

<br/>

## 🔧 리뷰 요구사항

처음에는 여러 장바구니 물품id를 List로 받아서 한번에 삭제하는 api 랑
하나의 id만 받아서 하나만 삭제하는 api를 구분해서 두 개를 만들려고 했는데요, 

물품 목록 삭제 기능을 먼저 구현해놓고 보니
List로 받는 api로 두 군데 다 사용이 가능한데 이걸 꼭 두 개를 구분해서 구현해야 하는건가? 싶은 생각이 들었습니다.
성능.. 차이가 많이 나기는 하나..? 싶은 생각이 들고?

특히 sql 을 잘 모르고 전체적으로 지식이 부족해서 판단하기가 힘드네요. 
다들 어떻게 생각하시나요


<br/>
