### PR TITLE
🐛Fix(order): 클라우드 기반 Redis 로 연결 시의 Reddison 커넥션 에러 해결

### DIFF
--- a/src/main/java/com/example/shoppingmall/global/config/RedissonConfig.java
+++ b/src/main/java/com/example/shoppingmall/global/config/RedissonConfig.java
@@ -21,12 +21,13 @@ public class RedissonConfig {
 
     private static final String REDISSON_HOST_PREFIX = "redis://";
 
-
     @Bean
     public RedissonClient redissonClient(){
         Config config = new Config();
         config.useSingleServer().setAddress(REDISSON_HOST_PREFIX + host + ":" + port)
-                .setPassword(password.isEmpty() ? null : password);
+                .setPassword(password.isEmpty() ? null : password)
+                .setConnectionPoolSize(2)
+                .setConnectionMinimumIdleSize(1);
 
         return Redisson.create(config);
     }


### PR DESCRIPTION
## 🔎 작업 내용

- 개인 로컬에 있는 redis로 작업 시 redisson 인스턴스 생성에 문제가 없었으나 
클라우드 기반 redis에 연결 시 정상 작동 되지 않으며 프로젝트 빌드가 되지 않는 상황이었습니다.

- 이미 프로젝트 내에서 레디스를 사용하고 있는 상황이고, redisson 설정 또한 같은 레디스를 사용하니까 문제가 없을 것이라고 생각했었습니다.
-  redisson  관련 에러 메세지를 보면 24개의 연결 중 1개만 초기화가 되었다. 라는 메세지가 있었고, 
커넥션 풀을 구성하는 과정에서 문제가 발생한 것으로 보였습니다. (디폴트 연결 개수가 24개..?)

- 찾아보니 클라우드 기반 Redis 서버에서는 기본적으로 설정된 연결 수 제한이 존재할 수 있다고 함

- reddison 관련 설정에서 커넥션 풀 사이즈 자체를 줄이거나, redis 서버의 최대 허용 연결 수를 늘리는 방법, 타임아웃 시간 늘리기 등이 있었고,
제 Redis 서버가 아니기때문에,  커넥션 풀 사이즈 자체를 줄이기로 결정 하였습니다. 
(조금씩 줄여봤는데, 계속 실패하다가 완전 낮게 잡으니까 정상적으로 만들어지더군요.)


  <br/>

## 이미지 첨부 (선)


<br/>

## 🔧 리뷰 요구사항

~~성공 후에는 pr에 넣을 내용 때문에, 
다시 커넥션 풀 사이즈 원래 디폴트 값으로 늘려서 시도한 뒤에 에러 메세지를 스샷으로 올릴려고 했는데, 
이제는 디폴트 값으로도 계속 정상이었습니다.  🤔...?
원인이 여러가지이던데, 뭔가 정확히 파악하려면 Redis 서버에서도 직접 로그, 설정 등을 봐야할 것 같습니다.
서버 주인님은 나중에 여유가 되시면 직접 해보시면 좋을 것 같고, 저도 나중에는 직접 제 껄로 만들어서 해봐야겠습니다.~~

-> 원인) 현재 사용중인 클라우드 기반 Redis 의 커넥션 제한은 30 이었는데,
Redisson 의 디폴트 연결 시도 개수는 24개였고, 
여러명이서 작업을 하면서  24 * n(팀원 수) 를  같은 Redis에 시도하는 상황이었기 때문
(다시 디폴트 값으로 돌렸는데, 정상 빌드가 됐던건 그 때  다들 서버를 올린 상태가 아니었기 때문이었던 것 같다.)

<br/>
